### PR TITLE
Use a different profile while executing commands from awscli for upda…

### DIFF
--- a/create-signed-binaries
+++ b/create-signed-binaries
@@ -376,10 +376,10 @@ task :upload do
   sh("aws s3 sync #{target_dir.join('upload', 'binaries')} s3://#{S3_BUCKET}/binaries/#{full_version} --cache-control 'max-age=31536000'")
 
   # copy the latest-version in a specific dir
-  sh("aws s3 cp #{target_dir.join('upload', 'update-check', 'latest.json')} s3://#{S3_UPDATE_CHECK_BUCKET}/channels/experimental/latest-#{full_version}.json --cache-control 'max-age=31536000'")
+  sh("AWS_PROFILE=update aws s3 cp #{target_dir.join('upload', 'update-check', 'latest.json')} s3://#{S3_UPDATE_CHECK_BUCKET}/channels/experimental/latest-#{full_version}.json --cache-control 'max-age=31536000'")
 
   # copy the top level latest-version in a specific dir
-  sh("aws s3 cp #{target_dir.join('upload', 'update-check', 'latest.json')} s3://#{S3_UPDATE_CHECK_BUCKET}/channels/experimental/latest.json --cache-control 'max-age=300'")
+  sh("AWS_PROFILE=update aws s3 cp #{target_dir.join('upload', 'update-check', 'latest.json')} s3://#{S3_UPDATE_CHECK_BUCKET}/channels/experimental/latest.json --cache-control 'max-age=300'")
 end
 
 task default: [*oses.keys, :metadata, 'target/latest.json', :prepare_for_upload, :verify_not_already_uploaded, :upload]

--- a/demote-from-stable
+++ b/demote-from-stable
@@ -25,7 +25,7 @@ task :default do
 
   $stderr.puts "*** Demoting version #{go_full_version} from stable"
 
-  sh("aws s3 cp s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.previous.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.json --cache-control 'max-age=600'")
+  sh("AWS_PROFILE=update aws s3 cp s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.previous.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.json --cache-control 'max-age=600'")
 
   sh("aws s3 rm --recursive s3://#{S3_STABLE_BUCKET}/binaries/#{go_full_version}/")
   sh("aws s3 rm --recursive s3://#{S3_ADDONS_STABLE_BUCKET}/#{go_full_version}/")

--- a/promote-to-stable
+++ b/promote-to-stable
@@ -34,7 +34,7 @@ task :default do
 
   sh("./create-repositories-stable")
 
-  sh("aws s3 cp s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.previous.json --cache-control 'max-age=600'")
+  sh("AWS_PROFILE=update aws s3 cp s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.previous.json --cache-control 'max-age=600'")
 
   sh("aws s3 cp s3://#{S3_EXPERIMENTAL_BUCKET}/binaries/#{go_full_version}/latest.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.json --cache-control 'max-age=600'")
   sh("aws s3 cp s3://#{S3_EXPERIMENTAL_BUCKET}/binaries/#{go_full_version}/latest.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest-#{go_full_version}.json --cache-control 'max-age=600'")


### PR DESCRIPTION
…te-check bucket as it belongs to a different stack.

@ketan - https://github.com/gocd/build_utilities/blob/master/promote-to-stable#L39-L40 - they do not need the profile specified right?