### PR TITLE
Fix bug in path during promotion

### DIFF
--- a/promote-to-stable
+++ b/promote-to-stable
@@ -27,6 +27,43 @@ password = ENV['ARTIFACT_FETCH_PASSWORD'] || 'password'
 version_info = JSON.parse(open("https://build.gocd.org/go/files/#{job_identifier}/dist/meta/version.json", 'r', http_basic_authentication: [username, password]).read)
 go_full_version = version_info['go_full_version']
 
+def path_without_bucket_name(s3_path_with_bucket)
+  s3_path_with_bucket.sub(%r{^[^/]+/}, '')
+end
+
+def metadata_for_stable_addon(path_to_addon_metadata)
+  metadata_file = Tempfile.new(['pg_metadata', '.json'], Dir.tmpdir)
+  sh("AWS_PROFILE=extensions aws s3 cp #{path_to_addon_metadata} #{metadata_file.path}")
+
+  JSON.parse(File.read(metadata_file.path)).tap do |metadata|
+    metadata['location'].sub!(/^#{path_without_bucket_name(S3_ADDONS_EXPERIMENTAL_BUCKET)}/, path_without_bucket_name(S3_ADDONS_STABLE_BUCKET))
+  end
+end
+
+task :update_addons_metadata do
+  path_to_s3_parent_of_addon = "#{path_without_bucket_name(S3_ADDONS_STABLE_BUCKET)}/#{go_full_version}"
+
+  pg_addon_metadata = AddonMetadata.new(
+    addon_file_s3_parent:  path_to_s3_parent_of_addon,
+    metadata_full_s3_path: "s3://#{S3_ADDONS_STABLE_BUCKET}/go-postgresql.json",
+    version:               go_full_version,
+    prefix:                'pg'
+  )
+
+  bc_addon_metadata = AddonMetadata.new(
+    addon_file_s3_parent:  path_to_s3_parent_of_addon,
+    metadata_full_s3_path: "s3://#{S3_ADDONS_STABLE_BUCKET}/go-business-continuity.json",
+    version:               go_full_version,
+    prefix:                'bc'
+  )
+
+  pg_addon_metadata.append_to_existing(metadata_for_stable_addon("s3://#{S3_ADDONS_EXPERIMENTAL_BUCKET}/#{go_full_version}/pg_metadata.json"))
+  bc_addon_metadata.append_to_existing(metadata_for_stable_addon("s3://#{S3_ADDONS_EXPERIMENTAL_BUCKET}/#{go_full_version}/bc_metadata.json"))
+
+  pg_addon_metadata.upload_combined_metadata_file
+  bc_addon_metadata.upload_combined_metadata_file
+end
+
 task :promote_artifacts_to_stable do
   $stderr.puts "*** Promoting version #{go_full_version} to stable"
 
@@ -42,35 +79,6 @@ task :promote_artifacts_to_stable do
   sh("AWS_PROFILE=update aws s3 cp /tmp/latest.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest.json --cache-control 'max-age=600' --acl public-read")
   sh("AWS_PROFILE=update aws s3 cp /tmp/latest.json s3://#{S3_UPDATE_CHECK_BUCKET}/channels/supported/latest-#{go_full_version}.json --cache-control 'max-age=600' --acl public-read")
   sh("rm /tmp/latest.json")
-end
-
-task :update_addons_metadata do
-  path_without_bucket_name = S3_ADDONS_STABLE_BUCKET.sub(%r{^[^/]+/}, '')
-
-  pg_addon_metadata = AddonMetadata.new(
-    addon_file_s3_parent:  "#{path_without_bucket_name}/#{go_full_version}",
-    metadata_full_s3_path: "s3://#{S3_ADDONS_STABLE_BUCKET}/go-postgresql.json",
-    version:               go_full_version,
-    prefix:                'pg'
-  )
-
-  bc_addon_metadata = AddonMetadata.new(
-    addon_file_s3_parent:  "#{path_without_bucket_name}/#{go_full_version}",
-    metadata_full_s3_path: "s3://#{S3_ADDONS_STABLE_BUCKET}/go-business-continuity.json",
-    version:               go_full_version,
-    prefix:                'bc'
-  )
-
-  pg_metadata_file = Tempfile.new(['pg_metadata', '.json'], Dir.tmpdir)
-  sh("AWS_PROFILE=extensions aws s3 cp s3://#{S3_ADDONS_EXPERIMENTAL_BUCKET}/#{go_full_version}/pg_metadata.json #{pg_metadata_file.path}")
-  pg_addon_metadata.append_to_existing(JSON.parse(File.read(pg_metadata_file.path)))
-
-  bc_metadata_file = Tempfile.new(['bc_metadata', '.json'], Dir.tmpdir)
-  sh("AWS_PROFILE=extensions aws s3 cp s3://#{S3_ADDONS_EXPERIMENTAL_BUCKET}/#{go_full_version}/bc_metadata.json #{bc_metadata_file.path}")
-  bc_addon_metadata.append_to_existing(JSON.parse(File.read(bc_metadata_file.path)))
-
-  pg_addon_metadata.upload_combined_metadata_file
-  bc_addon_metadata.upload_combined_metadata_file
 end
 
 task default: [:promote_artifacts_to_stable, :update_addons_metadata]


### PR DESCRIPTION
When promoting an addon from experimental to stable, the location changes (along with the bucket). This was missed. Now, location changes from `addons/experimental/V.E.R-SION/go-addon.jar` to `addons/V.E.R-SION/go-addon.jar`

cc @varshavaradarajan 